### PR TITLE
Support vertical video clips

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ Run the script with a video file:
 
 ```bash
 python autoedit.py path/to/video.mp4 --output-dir shorts
+# use --vertical to export 9:16 clips
+python autoedit.py path/to/video.mp4 --output-dir shorts --vertical
 ```
 
 This will:
@@ -34,7 +36,9 @@ This will:
 - `--summary-model` – summarization model (default `t5-small`).
 - `--num-clips` – number of highlight clips to produce (default `3`).
 - `--clip-duration` – length of each highlight in seconds (default `30`).
+- `--vertical` – export clips cropped/resized to 9:16 vertical aspect.
 
 ## Notes
 
 The summarization and transcription models are loaded locally, so large model files may be downloaded beforehand. Ensure you have enough disk space and GPU/CPU resources for processing.
+If you enable `--vertical`, the exported clips will be cropped or resized to a 9:16 aspect ratio.

--- a/autoedit.py
+++ b/autoedit.py
@@ -41,12 +41,32 @@ def find_highlight_segments(segments, summary: str, num_clips: int = 3, clip_dur
     return highlights
 
 
-def extract_clips(video_path: str, segments, output_dir: str, prefix: str = "clip"):
+def extract_clips(
+    video_path: str,
+    segments,
+    output_dir: str,
+    prefix: str = "clip",
+    aspect: str = "original",
+    vertical: bool = False,
+):
+    """Export highlight clips optionally cropped/resized to 9:16."""
+
     os.makedirs(output_dir, exist_ok=True)
     with VideoFileClip(video_path) as video:
         for idx, (start, end) in enumerate(segments):
             out_path = os.path.join(output_dir, f"{prefix}_{idx + 1}.mp4")
             subclip = video.subclip(start, end)
+
+            if vertical or aspect == "9:16":
+                width, height = subclip.size
+                if width / height > 9 / 16:
+                    new_width = int(height * 9 / 16)
+                    subclip = subclip.crop(x_center=width / 2, width=new_width)
+                else:
+                    new_height = int(width * 16 / 9)
+                    subclip = subclip.crop(y_center=height / 2, height=new_height)
+                subclip = subclip.resize(height=1080)
+
             subclip.write_videofile(out_path, codec="libx264", audio_codec="aac")
 
 
@@ -58,13 +78,14 @@ def main():
     parser.add_argument("--summary-model", default="t5-small", help="Summarization model")
     parser.add_argument("--num-clips", type=int, default=3, help="Number of highlight clips")
     parser.add_argument("--clip-duration", type=int, default=30, help="Length of each clip in seconds")
+    parser.add_argument("--vertical", action="store_true", help="Export clips in vertical 9:16 aspect")
     args = parser.parse_args()
 
     segments = transcribe(args.video, args.model)
     text = " ".join(seg["text"] for seg in segments)
     summary = summarize_text(text, args.summary_model)
     highlights = find_highlight_segments(segments, summary, args.num_clips, args.clip_duration)
-    extract_clips(args.video, highlights, args.output_dir)
+    extract_clips(args.video, highlights, args.output_dir, vertical=args.vertical)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- export highlight clips in 9:16 if `--vertical` is passed
- document the new `--vertical` option

## Testing
- `python -m py_compile autoedit.py`

------
https://chatgpt.com/codex/tasks/task_e_68424a7f684c8324b40085d42b21f616