### PR TITLE
Add automatic title and description generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ This will:
 1. Transcribe the video locally with WhisperX.
 2. Summarize the transcript to identify highlight segments.
 3. Export short clips into the `shorts` directory.
+4. Generate a short title and multi-sentence description for each clip using the summarization model.
 
 ### Options
 
@@ -38,3 +39,4 @@ This will:
 ## Notes
 
 The summarization and transcription models are loaded locally, so large model files may be downloaded beforehand. Ensure you have enough disk space and GPU/CPU resources for processing.
+When clips are generated, their titles and descriptions are printed to the console so you can easily reuse them.

--- a/autoedit.py
+++ b/autoedit.py
@@ -21,6 +21,14 @@ def summarize_text(text: str, model_name: str = "t5-small") -> str:
     return summary
 
 
+def generate_title_description(text: str, model_name: str = "t5-small"):
+    """Generate a short title and multi-sentence description from text."""
+    summarizer = pipeline("summarization", model=model_name)
+    title = summarizer(text, max_length=15, min_length=5)[0]["summary_text"].strip()
+    description = summarizer(text, max_length=80, min_length=30)[0]["summary_text"].strip()
+    return title, description
+
+
 def find_highlight_segments(segments, summary: str, num_clips: int = 3, clip_duration: int = 30):
     """Select highlight segments based on overlap with summary words."""
     summary_words = set(summary.lower().split())
@@ -37,17 +45,23 @@ def find_highlight_segments(segments, summary: str, num_clips: int = 3, clip_dur
             break
         start = seg["start"]
         end = min(seg["end"], start + clip_duration)
-        highlights.append((start, end))
+        highlights.append({"start": start, "end": end, "text": seg["text"]})
     return highlights
 
 
 def extract_clips(video_path: str, segments, output_dir: str, prefix: str = "clip"):
+    """Extract video clips and return their file paths with text."""
     os.makedirs(output_dir, exist_ok=True)
+    outputs = []
     with VideoFileClip(video_path) as video:
-        for idx, (start, end) in enumerate(segments):
+        for idx, seg in enumerate(segments):
+            start = seg["start"]
+            end = seg["end"]
             out_path = os.path.join(output_dir, f"{prefix}_{idx + 1}.mp4")
             subclip = video.subclip(start, end)
             subclip.write_videofile(out_path, codec="libx264", audio_codec="aac")
+            outputs.append((out_path, seg["text"]))
+    return outputs
 
 
 def main():
@@ -63,8 +77,18 @@ def main():
     segments = transcribe(args.video, args.model)
     text = " ".join(seg["text"] for seg in segments)
     summary = summarize_text(text, args.summary_model)
+    title, description = generate_title_description(summary, args.summary_model)
+    print("Video Title:", title)
+    print("Video Description:", description, "\n")
+
     highlights = find_highlight_segments(segments, summary, args.num_clips, args.clip_duration)
-    extract_clips(args.video, highlights, args.output_dir)
+    clips = extract_clips(args.video, highlights, args.output_dir)
+
+    for path, clip_text in clips:
+        c_title, c_desc = generate_title_description(clip_text, args.summary_model)
+        print(f"Clip: {path}")
+        print("Title:", c_title)
+        print("Description:", c_desc, "\n")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- generate a short title and multi-sentence description from text
- return clip text in `extract_clips` and use it to title each clip
- print titles and descriptions for the video and every clip
- document the new titling feature in the README

## Testing
- `python -m py_compile autoedit.py`

------
https://chatgpt.com/codex/tasks/task_e_68424a8079e0832499253f27478c61dc