### PR TITLE
Add GUI option for AutoEdit file selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ python autoedit.py path/to/video.mp4 --output-dir shorts
 python autoedit.py path/to/video.mp4 --output-dir shorts --vertical
 ```
 
+Or open a file chooser window so you don't have to type the path:
+
+```bash
+python autoedit.py --gui --output-dir shorts
+```
+
 This will:
 
 1. Transcribe the video locally with faster-whisper.
@@ -38,6 +44,7 @@ This will:
 - `--num-clips` – number of highlight clips to produce (default `3`).
 - `--clip-duration` – length of each highlight in seconds (default `30`).
 - `--vertical` – export clips cropped/resized to 9:16 vertical aspect.
+- `--gui` – open a file chooser to select the input video.
 
 ## Notes
 


### PR DESCRIPTION
## Summary
- add `select_video_gui()` for choosing a video through a file dialog
- support `--gui` flag to open the dialog when running `autoedit.py`
- allow optional `video` positional argument
- document GUI usage in README

## Testing
- `python -m py_compile autoedit.py`
- `python autoedit.py --help` *(fails: ModuleNotFoundError: No module named 'faster_whisper')*

------
https://chatgpt.com/codex/tasks/task_e_68425f0e09f08324a0e5f97aa52dbf59